### PR TITLE
fixes #16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '5'
 after_success:
   - npm run coveralls
 notifications:

--- a/lib/HalModuleParser.js
+++ b/lib/HalModuleParser.js
@@ -272,13 +272,17 @@ HalModuleParser.prototype = {
 	 * @private
 	 */
 	_readPrefix: function(fileBuffer) {
-		var isLittleEndian = true;
 		var prefixOffset = this._divineModulePrefixOffset(fileBuffer);
 		var r = new buffers.BufferReader(fileBuffer);
 
 		// skip to system module offset, or stay at user module no offset
 		r.skip(prefixOffset);
 
+		return this._parsePrefix(r);
+	},
+
+	_parsePrefix: function(r) {
+		var isLittleEndian = true;
 		//offset 0, 4-bytes: module start address
 		var moduleStartAddy = r.shiftUInt32(isLittleEndian).toString(16);
 
@@ -308,7 +312,7 @@ HalModuleParser.prototype = {
 		var depModuleIndex = r.shiftUInt8(isLittleEndian);
 
 		// offset 18, 1-byte: minimum version of system dependency
-		var depModuleVersion = r.shiftUInt8(isLittleEndian);
+		var depModuleVersion = r.shiftUInt16(isLittleEndian);
 
 		return {
 			moduleStartAddy: moduleStartAddy,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "buffer-offset": "^0.1.2",
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Fixes #16. Changes the module dependency version from 8-bits to 16-bits. Module versions for 0.8.0 firmware start at 300. 

See https://github.com/spark/firmware/commit/ad813c20e96c8b2b1ee1a186425c7a7ab7ee04c4#diff-bc30c65adb2f72b90c09644643d56f1aR36