### PR TITLE
Fixes `areDependenciesMet()` in case of multiple dependencies

### DIFF
--- a/lib/FirmwareModule.js
+++ b/lib/FirmwareModule.js
@@ -106,7 +106,11 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 
 		var HalDependencyResolver = require('./HalDependencyResolver');
 		var resolver = new HalDependencyResolver();
-		var invalidModules = resolver.solveFirmwareModule(deviceModules, this.dependencies[0]);
+		let invalidModules = [];
+		for (let dep of this.dependencies) {
+			const invalidDependencyModules = resolver.solveFirmwareModule(deviceModules, dep);
+			invalidModules = invalidModules.concat(invalidDependencyModules);
+		}
 		return invalidModules.length === 0;
 	}
 });

--- a/lib/FirmwareModule.js
+++ b/lib/FirmwareModule.js
@@ -98,6 +98,9 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 	areDependenciesMet: function(deviceModules, invalidModules) {
 		invalidModules = invalidModules || [];
 
+		// Make sure the array is empty
+		invalidModules.length = 0;
+
 		if (!deviceModules) {
 			return false;
 		}
@@ -111,7 +114,7 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 
 		for (let dep of this.dependencies) {
 			const invalidDependencyModules = resolver.solveFirmwareModule(deviceModules, dep);
-			invalidModules = invalidModules.concat(invalidDependencyModules);
+			invalidModules.push.apply(invalidModules, invalidDependencyModules);
 		}
 		return invalidModules.length === 0;
 	}

--- a/lib/FirmwareModule.js
+++ b/lib/FirmwareModule.js
@@ -98,9 +98,6 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 	areDependenciesMet: function(deviceModules, invalidModules) {
 		invalidModules = invalidModules || [];
 
-		// Make sure the array is empty
-		invalidModules.length = 0;
-
 		if (!deviceModules) {
 			return false;
 		}

--- a/lib/FirmwareModule.js
+++ b/lib/FirmwareModule.js
@@ -114,7 +114,7 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 
 		for (let dep of this.dependencies) {
 			const invalidDependencyModules = resolver.solveFirmwareModule(deviceModules, dep);
-			invalidModules.push.apply(invalidModules, invalidDependencyModules);
+			invalidModules.push.apply(invalidModules, invalidDependencyModules.map(m => new FirmwareModule(m)));
 		}
 		return invalidModules.length === 0;
 	}

--- a/lib/FirmwareModule.js
+++ b/lib/FirmwareModule.js
@@ -95,7 +95,9 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 		}
 	},
 
-	areDependenciesMet: function(deviceModules) {
+	areDependenciesMet: function(deviceModules, invalidModules) {
+		invalidModules = invalidModules || [];
+
 		if (!deviceModules) {
 			return false;
 		}
@@ -106,7 +108,7 @@ FirmwareModule.prototype = extend(FirmwareModule.prototype, {
 
 		var HalDependencyResolver = require('./HalDependencyResolver');
 		var resolver = new HalDependencyResolver();
-		let invalidModules = [];
+
 		for (let dep of this.dependencies) {
 			const invalidDependencyModules = resolver.solveFirmwareModule(deviceModules, dep);
 			invalidModules = invalidModules.concat(invalidDependencyModules);

--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -443,7 +443,7 @@ HalDependencyResolver.prototype = {
 			var missing = extend(foundModule, { v: needs.v });
 			arr.push(missing);
 			// todo mdm - this is wrong. we shouldn't be fabricating dependencies for a new version of a module
-			// (need) from the installed version (m) - dependencies can and do change between versions.
+			// (need) from the installed version (foundModule) - dependencies can and do change between versions.
 			// The database of known modules should be the definitive source of module dependencies.
 
 			// if we're updating this, we better check its dependencies too.

--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -18,6 +18,8 @@
  * Created by middleca on 6/18/15.
  */
 
+'use strict';
+
 var fs = require('fs');
 var when = require('when');
 var pipeline = require('when/pipeline');

--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -27,6 +27,7 @@ var utilities = require('./utilities.js');
 
 var HalModuleParser = require('./HalModuleParser.js');
 var FirmwareModule = require('./FirmwareModule');
+const ModuleInfo = require('./ModuleInfo');
 
 /**
  * fancy module that can assimilate system modules and their version info.
@@ -400,54 +401,58 @@ HalDependencyResolver.prototype = {
 	_walkChain: function(modules, needs, arr) {
 		arr = arr || [];
 
-		// todo - this assumes the entire set of dependencies exists on the device (i.e. a module with the same n/f values)
-		// but this is not the case, e.g. when upgrading from a 2 module system to 3 module system.
-		for (var i = 0; i < modules.length; i++) {
-			var m = modules[i];
+		// Skip dependencies with function = "none"
+		if (needs.f === ModuleInfo.FunctionChar.NONE) {
+			return arr;
+		}
 
-			if (m.n !== needs.n) {
-				continue;
+		let foundModule = null;
+
+		for (let m of modules) {
+			if (m.n === needs.n && m.f === needs.f) {
+				foundModule = m;
+				break;
 			}
-			if (m.f !== needs.f) {
-				continue;
-			}
+		}
 
-			//found one!
-			if (m.v < needs.v) {
-				//
-				// it's...
-				//	  .---.       .-''-.     .-'''-.    .-'''-.     ,---------. .---.  .---.    ____    ,---.   .--.
-				//	  | ,_|     .'_ _   \   / _     \  / _     \    \          \|   |  |_ _|  .'  __ `. |    \  |  |
-				//	,-./  )    / ( ` )   ' (`' )/`--' (`' )/`--'     `--.  ,---'|   |  ( ' ) /   '  \  \|  ,  \ |  |
-				//	\  '_ '`) . (_ o _)  |(_ o _).   (_ o _).           |   \   |   '-(_{;}_)|___|  /  ||  |\_ \|  |
-				//	 > (_)  ) |  (_,_)___| (_,_). '.  (_,_). '.         :_ _:   |      (_,_)    _.-`   ||  _( )_\  |
-				//	(  .  .-' '  \   .---..---.  \  :.---.  \  :        (_I_)   | _ _--.   | .'   _    || (_ o _)  |
-				//	 `-'`-'|___\  `-'    /\    `-'  |\    `-'  |       (_(=)_)  |( ' ) |   | |  _( )_  ||  (_,_)\  |
-				//	  |        \\       /  \       /  \       /         (_I_)   (_{;}_)|   | \ (_ o _) /|  |    |  |
-				//	  `--------` `'-..-'    `-...-'    `-...-'          '---'   '(_,_) '---'  '.(_,_).' '--'    '--'
-				//
+		if (!foundModule) {
+			// Module is not present in the list of modules on the device
+			// Simply return the dependency as-is
+			arr.push(needs);
+		} else if (foundModule.v < needs.v) {
+			//
+			// it's...
+			//	  .---.       .-''-.     .-'''-.    .-'''-.     ,---------. .---.  .---.    ____    ,---.   .--.
+			//	  | ,_|     .'_ _   \   / _     \  / _     \    \          \|   |  |_ _|  .'  __ `. |    \  |  |
+			//	,-./  )    / ( ` )   ' (`' )/`--' (`' )/`--'     `--.  ,---'|   |  ( ' ) /   '  \  \|  ,  \ |  |
+			//	\  '_ '`) . (_ o _)  |(_ o _).   (_ o _).           |   \   |   '-(_{;}_)|___|  /  ||  |\_ \|  |
+			//	 > (_)  ) |  (_,_)___| (_,_). '.  (_,_). '.         :_ _:   |      (_,_)    _.-`   ||  _( )_\  |
+			//	(  .  .-' '  \   .---..---.  \  :.---.  \  :        (_I_)   | _ _--.   | .'   _    || (_ o _)  |
+			//	 `-'`-'|___\  `-'    /\    `-'  |\    `-'  |       (_(=)_)  |( ' ) |   | |  _( )_  ||  (_,_)\  |
+			//	  |        \\       /  \       /  \       /         (_I_)   (_{;}_)|   | \ (_ o _) /|  |    |  |
+			//	  `--------` `'-..-'    `-...-'    `-...-'          '---'   '(_,_) '---'  '.(_,_).' '--'    '--'
+			//
 
-				//arr.push(m);
+			//arr.push(foundModule);
 
-				// instead of returning the module we found, lets return the module with the version we need,
-				// and any dependencies it requires, I think that's more clear.
+			// instead of returning the module we found, lets return the module with the version we need,
+			// and any dependencies it requires, I think that's more clear.
 
-				var missing = extend(m, { v: needs.v });
-				arr.push(missing);
-				// todo mdm - this is wrong. we shouldn't be fabricating dependencies for a new version of a module
-				// (need) from the installed version (m) - dependencies can and do change between versions.
-				// The database of known modules should be the definitive source of module dependencies.
+			var missing = extend(foundModule, { v: needs.v });
+			arr.push(missing);
+			// todo mdm - this is wrong. we shouldn't be fabricating dependencies for a new version of a module
+			// (need) from the installed version (m) - dependencies can and do change between versions.
+			// The database of known modules should be the definitive source of module dependencies.
 
-				// if we're updating this, we better check its dependencies too.
-				if (m.d && (m.d.length > 0)) {
-					//oh no!  this module has dependencies!
-					// do we have to update those too?
-					// (this doesn't fully make sense to me right now, but lets go with it.)
-					// todo mdm - this won't do anything, since `m` is always a satisfied dependency
-					// (it came from the modules array.)
-					// at the very least we should be iterating over m.d[] as the needed modules
-					arr = this._walkChain(modules, m, arr);
-				}
+			// if we're updating this, we better check its dependencies too.
+			if (foundModule.d && (foundModule.d.length > 0)) {
+				//oh no!  this module has dependencies!
+				// do we have to update those too?
+				// (this doesn't fully make sense to me right now, but lets go with it.)
+				// todo mdm - this won't do anything, since `m` is always a satisfied dependency
+				// (it came from the modules array.)
+				// at the very least we should be iterating over foundModule.d[] as the needed modules
+				arr = this._walkChain(modules, foundModule, arr);
 			}
 		}
 

--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -438,13 +438,10 @@ HalDependencyResolver.prototype = {
 			//arr.push(foundModule);
 
 			// instead of returning the module we found, lets return the module with the version we need,
-			// and any dependencies it requires, I think that's more clear.
-
-			var missing = extend(foundModule, { v: needs.v });
+			// _and cleared dependencies_, as we have no idea what that module actually might require.
+			// In previous versions, we used to return dependencies of the old module.
+			var missing = extend(foundModule, { v: needs.v, d: [] });
 			arr.push(missing);
-			// todo mdm - this is wrong. we shouldn't be fabricating dependencies for a new version of a module
-			// (need) from the installed version (foundModule) - dependencies can and do change between versions.
-			// The database of known modules should be the definitive source of module dependencies.
 
 			// if we're updating this, we better check its dependencies too.
 			if (foundModule.d && (foundModule.d.length > 0)) {

--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -82,7 +82,7 @@ const HEADER_SIZE = 24;
 
 module.exports = {
     FunctionType: ModuleFunction,
-    FunctionChar: ModuleFunction,
+    FunctionChar: ModuleFunctionChar,
     Flags: ModuleInfoFlags,
     FunctionToChar: ModuleFunctionToChar,
     ValidationFlags: ModuleValidationFlags,

--- a/specs/describes/modules.json.js
+++ b/specs/describes/modules.json.js
@@ -1,0 +1,62 @@
+module.exports = {
+	message: {
+		s: 131072,
+		l: "m",
+		vc: 30,
+		vv: 30,
+		u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
+		f: "u",
+		n: "1",
+		v: 3,
+		d: [
+			{
+				f: "s",
+				n: "2",
+				v: 5,
+				_: ""
+			}
+		]
+	},
+	messageMultipleDependencies: {
+		s: 131072,
+		l: "m",
+		vc: 30,
+		vv: 30,
+		u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
+		f: "u",
+		n: "1",
+		v: 3,
+		d: [
+			{
+				f: "s",
+				n: "1",
+				v: 5,
+				_: ""
+			},
+			{
+				f: "s",
+				n: "2",
+				v: 5,
+				_: ""
+			}
+		]
+	},
+	messageWithDependencyNotInDeviceDescribe: {
+		s: 131072,
+		l: "m",
+		vc: 30,
+		vv: 30,
+		u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
+		f: "u",
+		n: "1",
+		v: 3,
+		d: [
+			{
+				f: "a",
+				n: "0",
+				v: 123,
+				_: ""
+			}
+		]
+	}
+};

--- a/specs/lib/FirmwareModule.spec.js
+++ b/specs/lib/FirmwareModule.spec.js
@@ -1,3 +1,4 @@
+'use strict';
 var should = require('should');
 var FirmwareModule = require('../../lib/FirmwareModule');
 const ModuleInfo = require('../../lib/ModuleInfo');

--- a/specs/lib/FirmwareModule.spec.js
+++ b/specs/lib/FirmwareModule.spec.js
@@ -1,5 +1,6 @@
 var should = require('should');
 var FirmwareModule = require('../../lib/FirmwareModule');
+const ModuleInfo = require('../../lib/ModuleInfo');
 
 const message = {
 	s: 131072,
@@ -138,6 +139,23 @@ describe('FirmwareModule', function(){
 		result.should.eql(false);
 
 		module.dependencies[1].version = 2;
+		result = module.areDependenciesMet(data.m);
+		result.should.eql(true);
+	});
+
+	it('should return dependency resolution status with module function "none"', function(){
+		const module = new FirmwareModule(messageMultipleDependencies);
+
+		const data = require('./../describes/fixed_dependencies_describe.json.js');
+
+		let result = module.areDependenciesMet(data.m);
+		result.should.eql(false);
+
+		module.dependencies[0].func = ModuleInfo.FunctionChar.NONE;
+		result = module.areDependenciesMet(data.m);
+		result.should.eql(false);
+
+		module.dependencies[1].func = ModuleInfo.FunctionChar.NONE;
 		result = module.areDependenciesMet(data.m);
 		result.should.eql(true);
 	});

--- a/specs/lib/FirmwareModule.spec.js
+++ b/specs/lib/FirmwareModule.spec.js
@@ -1,7 +1,7 @@
 var should = require('should');
 var FirmwareModule = require('../../lib/FirmwareModule');
 
-var message = {
+const message = {
 	s: 131072,
 	l: "m",
 	vc: 30,
@@ -11,6 +11,31 @@ var message = {
 	n: "1",
 	v: 3,
 	d: [
+		{
+			f: "s",
+			n: "2",
+			v: 5,
+			_: ""
+		}
+	]
+};
+
+const messageMultipleDependencies = {
+	s: 131072,
+	l: "m",
+	vc: 30,
+	vv: 30,
+	u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
+	f: "u",
+	n: "1",
+	v: 3,
+	d: [
+		{
+			f: "s",
+			n: "1",
+			v: 5,
+			_: ""
+		},
 		{
 			f: "s",
 			n: "2",
@@ -97,6 +122,23 @@ describe('FirmwareModule', function(){
 		module.dependencies[0].version = 2;
 
 		var result = module.areDependenciesMet(data.m);
+		result.should.eql(true);
+	});
+
+	it('should return dependency resolution status for multiple dependencies', function(){
+		const module = new FirmwareModule(messageMultipleDependencies);
+
+		const data = require('./../describes/fixed_dependencies_describe.json.js');
+
+		let result = module.areDependenciesMet(data.m);
+		result.should.eql(false);
+
+		module.dependencies[0].version = 2;
+		result = module.areDependenciesMet(data.m);
+		result.should.eql(false);
+
+		module.dependencies[1].version = 2;
+		result = module.areDependenciesMet(data.m);
 		result.should.eql(true);
 	});
 });

--- a/specs/lib/FirmwareModule.spec.js
+++ b/specs/lib/FirmwareModule.spec.js
@@ -1,53 +1,11 @@
 var should = require('should');
 var FirmwareModule = require('../../lib/FirmwareModule');
 const ModuleInfo = require('../../lib/ModuleInfo');
-
-const message = {
-	s: 131072,
-	l: "m",
-	vc: 30,
-	vv: 30,
-	u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
-	f: "u",
-	n: "1",
-	v: 3,
-	d: [
-		{
-			f: "s",
-			n: "2",
-			v: 5,
-			_: ""
-		}
-	]
-};
-
-const messageMultipleDependencies = {
-	s: 131072,
-	l: "m",
-	vc: 30,
-	vv: 30,
-	u: "7F2F2B5C5A4F40D9844D109B7FBD730BF2237C252EF03ED5075CEB9901AF985E",
-	f: "u",
-	n: "1",
-	v: 3,
-	d: [
-		{
-			f: "s",
-			n: "1",
-			v: 5,
-			_: ""
-		},
-		{
-			f: "s",
-			n: "2",
-			v: 5,
-			_: ""
-		}
-	]
-};
+const testModules = require('./../describes/modules.json.js');
 
 describe('FirmwareModule', function(){
 	it('should parse describe message', function(){
+		const message = testModules.message;
 		var module = new FirmwareModule(message);
 		module.uuid.should.eql(message.u);
 		module.func.should.eql(message.f);
@@ -100,6 +58,7 @@ describe('FirmwareModule', function(){
 	});
 
 	it('should return describe like object', function(){
+		const message = testModules.message;
 		var module = new FirmwareModule(message);
 		var describe = module.toDescribe();
 		describe.u.should.eql(describe.u);
@@ -114,6 +73,7 @@ describe('FirmwareModule', function(){
 	});
 
 	it('should return dependency resolution status', function(){
+		const message = testModules.message;
 		var module = new FirmwareModule(message);
 		var data = require('./../describes/fixed_dependencies_describe.json.js');
 
@@ -127,7 +87,8 @@ describe('FirmwareModule', function(){
 	});
 
 	it('should return dependency resolution status for multiple dependencies', function(){
-		const module = new FirmwareModule(messageMultipleDependencies);
+		const message = testModules.messageMultipleDependencies;
+		const module = new FirmwareModule(message);
 
 		const data = require('./../describes/fixed_dependencies_describe.json.js');
 
@@ -144,7 +105,8 @@ describe('FirmwareModule', function(){
 	});
 
 	it('should return dependency resolution status with module function "none"', function(){
-		const module = new FirmwareModule(messageMultipleDependencies);
+		const message = testModules.messageMultipleDependencies;
+		const module = new FirmwareModule(message);
 
 		const data = require('./../describes/fixed_dependencies_describe.json.js');
 
@@ -158,5 +120,15 @@ describe('FirmwareModule', function(){
 		module.dependencies[1].func = ModuleInfo.FunctionChar.NONE;
 		result = module.areDependenciesMet(data.m);
 		result.should.eql(true);
+	});
+
+	it('should return dependency resolution status when dependency is not present in device describe', function(){
+		const message = testModules.messageWithDependencyNotInDeviceDescribe;
+		const module = new FirmwareModule(message);
+
+		const data = require('./../describes/fixed_dependencies_describe.json.js');
+
+		let result = module.areDependenciesMet(data.m);
+		result.should.eql(false);
 	});
 });

--- a/specs/lib/FirmwareModule.spec.js
+++ b/specs/lib/FirmwareModule.spec.js
@@ -78,13 +78,17 @@ describe('FirmwareModule', function(){
 		var module = new FirmwareModule(message);
 		var data = require('./../describes/fixed_dependencies_describe.json.js');
 
-		var result = module.areDependenciesMet(data.m);
+		let unmet = [];
+		var result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(1);
 
 		module.dependencies[0].version = 2;
 
-		var result = module.areDependenciesMet(data.m);
+		unmet = [];
+		var result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(true);
+		unmet.should.have.lengthOf(0);
 	});
 
 	it('should return dependency resolution status for multiple dependencies', function(){
@@ -93,16 +97,22 @@ describe('FirmwareModule', function(){
 
 		const data = require('./../describes/fixed_dependencies_describe.json.js');
 
-		let result = module.areDependenciesMet(data.m);
+		let unmet = [];
+		let result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(2);
 
 		module.dependencies[0].version = 2;
-		result = module.areDependenciesMet(data.m);
+		unmet = [];
+		result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(1);
 
 		module.dependencies[1].version = 2;
-		result = module.areDependenciesMet(data.m);
+		unmet = [];
+		result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(true);
+		unmet.should.have.lengthOf(0);
 	});
 
 	it('should return dependency resolution status with module function "none"', function(){
@@ -111,16 +121,22 @@ describe('FirmwareModule', function(){
 
 		const data = require('./../describes/fixed_dependencies_describe.json.js');
 
-		let result = module.areDependenciesMet(data.m);
+		let unmet = [];
+		let result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(2);
 
 		module.dependencies[0].func = ModuleInfo.FunctionChar.NONE;
-		result = module.areDependenciesMet(data.m);
+		unmet = [];
+		result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(1);
 
 		module.dependencies[1].func = ModuleInfo.FunctionChar.NONE;
-		result = module.areDependenciesMet(data.m);
+		unmet = [];
+		result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(true);
+		unmet.should.have.lengthOf(0);
 	});
 
 	it('should return dependency resolution status when dependency is not present in device describe', function(){
@@ -129,7 +145,9 @@ describe('FirmwareModule', function(){
 
 		const data = require('./../describes/fixed_dependencies_describe.json.js');
 
-		let result = module.areDependenciesMet(data.m);
+		const unmet = [];
+		let result = module.areDependenciesMet(data.m, unmet);
 		result.should.eql(false);
+		unmet.should.have.lengthOf(1);
 	});
 });

--- a/specs/lib/HalDependencyResolver.spec.js
+++ b/specs/lib/HalDependencyResolver.spec.js
@@ -88,7 +88,7 @@ describe('HalDependencyResolver', function() {
 			v: systemPart2.v + 1
 		};
 
-		var shouldBeMissing = extend(fixedTestData[2], { v: systemPart2.v + 1 });
+		var shouldBeMissing = extend(fixedTestData[2], { v: systemPart2.v + 1, d: [] });
 
 		var resolver = new HalDependencyResolver();
 		var arr = resolver._walkChain(fixedTestData, safeBinaryReqs);


### PR DESCRIPTION
### Problem

Currently `FirmwareModule.areDependenciesMet()` does not correctly handle multiple dependencies, which we do have (2).

### Solution

1. Fixes its behavior
2. Adds an optional argument `invalidModules` to be populated with module info of unmet dependencies