### PR TITLE
ignore factory module when looking for missing dependencies

### DIFF
--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -290,7 +290,7 @@ HalDependencyResolver.prototype = {
 	solveFirmwareModule: function(deviceModules, firmwareModule) {
 		var safeDeviceModules = this._repairDescribeErrors(deviceModules);
 		var safeModuleRequires = firmwareModule.toDescribe();
-		
+
 		return this._walkChain(safeDeviceModules, safeModuleRequires);
 	},
 
@@ -352,11 +352,13 @@ HalDependencyResolver.prototype = {
 	 * in what order should we apply updates?
 	 * is it possible for us to get conflicting / out of order update recommendations?!
 	 *
-	 * @param describe
+	 * @param {object} describe     The describe message from the device
+	 * @param {object} options      Optional options controlling which dependencies are checked
+	 * @property {boolean} options.includeFactoryFirmware    When true, firmware at the factory location is included.
 	 */
-	findAnyMissingDependencies: function(describe) {
+	findAnyMissingDependencies: function(describe, options) {
 		if (!Array.isArray(describe.m)) {
-			return when.reject('no modules in describe message');
+			return;
 		}
 
 		var allDeps = [];
@@ -364,6 +366,10 @@ HalDependencyResolver.prototype = {
 
 		for(var i=0;i<modules.length;i++) {
 			var checkModule = modules[i];
+
+			if (checkModule.l === 'f' && !(options && options.includeFactoryFirmware)) {
+				continue;
+			}
 
 			// don't look for dependencies of things that don't have dependencies.
 			// they'll never cause safe mode as a result of their requirements,
@@ -381,8 +387,7 @@ HalDependencyResolver.prototype = {
 		}
 
 		var keyFn = function(dep) {
-			// todo - location should also be taken into account
-			return [dep.f, dep.n, dep.v].join('_');
+			return [dep.f, dep.n, dep.v || ''].join('_');
 		};
 		return utilities.dedupArray(allDeps, keyFn);
 	},

--- a/specs/lib/HalDependencyResolver.spec.js
+++ b/specs/lib/HalDependencyResolver.spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  *  Copyright 2015 Particle ( https://particle.io )
  *
@@ -26,6 +27,7 @@ var when = require('when');
 var pipeline = require('when/pipeline');
 var HalDependencyResolver = require ('../../lib/HalDependencyResolver.js');
 var FirmwareModule = require('../../lib/FirmwareModule');
+var expect = require('chai').expect;
 
 var settings = {
 	binaries: path.resolve(path.join(__dirname, '../binaries'))
@@ -383,4 +385,50 @@ describe('HalDependencyResolver', function() {
 
 		done();
 	});
+
+
+	describe('factory image', () => {
+		function hasMissingDependencies(describe) {
+			const modules = new HalDependencyResolver().findAnyMissingDependencies(describe);
+			return modules && modules.length > 0;
+		}
+
+		it('does not report safe mode for factory modules that are invalid', () => {
+
+			const describe = { 'p':13,'m':[{ 's':49152,'l':'m','vc':30,'vv':30,'f':'b','n':'0','v':300,'d':[] },{ 's':671744,'l':'m','vc':30,'vv':30,'f':'s','n':'1','v':403,'d':[{ 'f':'b','n':'0','v':101,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'m','vc':30,'vv':30,'u':'09B7930F35B990D0021501E62007AE48BBC68E6422CE4504B2BA6DEA7F5E1C45','f':'u','n':'1','v':5,'d':[{ 'f':'s','n':'1','v':403,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'f','vc':30,'vv':0,'d':[{ 'f':'_','n':'6','v':0,'_':'' },{ 'f':'_','n':'6','v':0,'_':'' }] }] };
+
+			expect(hasMissingDependencies(describe)).to.be.eql(false);
+		});
+
+		it('does not report safe mode for factory modules that are invalid', () => {
+
+			const describe = { 'p':13,'m':[{ 's':49152,'l':'m','vc':30,'vv':30,'f':'b','n':'0','v':300,'d':[] },{ 's':671744,'l':'m','vc':30,'vv':30,'f':'s','n':'1','v':403,'d':[{ 'f':'b','n':'0','v':101,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'m','vc':30,'vv':30,'u':'09B7930F35B990D0021501E62007AE48BBC68E6422CE4504B2BA6DEA7F5E1C45','f':'u','n':'1','v':5,'d':[{ 'f':'s','n':'1','v':403,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'f','vc':30,'vv':0,'d':[{ 'f':'_','n':'6','v':0,'_':'' },{ 'f':'_','n':'6','v':0,'_':'' }] }] };
+
+			expect(hasMissingDependencies(describe)).to.be.eql(false);
+		});
+
+		it('does not report safe mode for factory modules that are valid', () => {
+
+			const describe = { 'p':13,'m':[{ 's':49152,'l':'m','vc':30,'vv':30,'f':'b','n':'0','v':300,'d':[] },{ 's':671744,'l':'m','vc':30,'vv':30,'f':'s','n':'1','v':403,'d':[{ 'f':'b','n':'0','v':101,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'m','vc':30,'vv':30,'u':'09B7930F35B990D0021501E62007AE48BBC68E6422CE4504B2BA6DEA7F5E1C45','f':'u','n':'1','v':5,'d':[{ 'f':'s','n':'1','v':403,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'f','vc':30,'vv':30,'d':[{ 'f':'_','n':'6','v':0,'_':'' },{ 'f':'_','n':'6','v':0,'_':'' }] }] };
+
+			expect(hasMissingDependencies(describe)).to.be.eql(false);
+		});
+
+
+		it('does not report safe mode for no missing dependencies', () => {
+
+			const describe = { 'p':13,'m':[{ 's':49152,'l':'m','vc':30,'vv':30,'f':'b','n':'0','v':300,'d':[] },{ 's':671744,'l':'m','vc':30,'vv':30,'f':'s','n':'1','v':403,'d':[{ 'f':'b','n':'0','v':101,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'m','vc':30,'vv':30,'u':'09B7930F35B990D0021501E62007AE48BBC68E6422CE4504B2BA6DEA7F5E1C45','f':'u','n':'1','v':5,'d':[{ 'f':'s','n':'1','v':403,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] }] };
+
+			expect(hasMissingDependencies(describe)).to.be.eql(false);
+		});
+
+		it('reports safe mode for missing application dependencies', () => {
+
+			const describe = { 'p':13,'m':[{ 's':49152,'l':'m','vc':30,'vv':30,'f':'b','n':'0','v':300,'d':[] },{ 's':671744,'l':'m','vc':30,'vv':30,'f':'s','n':'1','v':403,'d':[{ 'f':'b','n':'0','v':101,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] },{ 's':131072,'l':'m','vc':30,'vv':30,'u':'09B7930F35B990D0021501E62007AE48BBC68E6422CE4504B2BA6DEA7F5E1C45','f':'u','n':'1','v':5,'d':[{ 'f':'s','n':'1','v':9999,'_':'' },{ 'f':'n','n':'0','v':0,'_':'' }] }] };
+
+			expect(hasMissingDependencies(describe)).to.be.eql(true);
+		});
+
+	});
+
 });


### PR DESCRIPTION
The factory module does not contribute to safe mode it is simply a backup region and corrupt data here was causing the safe mode detector to report a false positive.

There are no current situations where the factory module should be included in the dependency resolution since it does not put the device in safe mode when its dependencies are not satisfied.

References:

* [CH44434](https://app.clubhouse.io/particle/story/44434/devices-are-incorrectly-reported-as-being-in-safe-mode)

