### PR TITLE
Feature/os first

### DIFF
--- a/lib/HalDependencyResolver.js
+++ b/lib/HalDependencyResolver.js
@@ -212,7 +212,7 @@ HalDependencyResolver.prototype = {
 
 	/*
 	 * expects the array of module descriptions back from the solve routine
-	 * and returns amodule description result complete with fileBuffer
+	 * and returns a module description result complete with fileBuffer
 	 * @param Array modules
 	 * @returns Object
 	 */

--- a/lib/HalModuleParser.js
+++ b/lib/HalModuleParser.js
@@ -90,7 +90,8 @@ HalModuleParser.prototype = {
 	 * @returns Promise
 	 */
 	parseBuffer: function(fileInfo, callback) {
-		if (!Buffer.isBuffer(fileInfo.fileBuffer)) {
+		// todo - ensure that this is not destructive
+		if (!Buffer.isBuffer(fileInfo.fileBuffer) || fileInfo.fileBuffer.length < 128) {
 			return when.reject('fileBuffer was invalid');
 		}
 

--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -81,6 +81,33 @@ const ModuleInfoPlatform = {
 
 const HEADER_SIZE = 24;
 
+function moduleFunctionToChar(f) {
+    let moduleFunction;
+
+    if (f && f < ModuleFunctionToChar.length) {
+        moduleFunction = ModuleFunctionToChar[f];
+    }
+
+    return moduleFunction;
+}
+
+function addDependency(to, f, index, version) {
+    const depFunction = moduleFunctionToChar(f);
+    if (depFunction) {
+        to.push({f: depFunction, v: version, n: ''+index});
+    }
+}
+
+
+function parsedModuleToDescribe(info) {
+    const prefix = info.prefixInfo;
+    const moduleFunction = moduleFunctionToChar(prefix.moduleFunction);
+    const dependencies = [];
+    addDependency(dependencies, prefix.depModuleFunction, prefix.depModuleIndex, prefix.depModuleVersion);
+    addDependency(dependencies, prefix.dep2ModuleFunction, prefix.dep2ModuleIndex, prefix.dep2ModuleVersion);
+    return { f: moduleFunction, n: ''+prefix.moduleIndex, v: prefix.moduleVersion, d: dependencies };
+}
+
 module.exports = {
     FunctionType: ModuleFunction,
     FunctionChar: ModuleFunctionChar,
@@ -88,5 +115,6 @@ module.exports = {
     FunctionToChar: ModuleFunctionToChar,
     ValidationFlags: ModuleValidationFlags,
     Platform: ModuleInfoPlatform,
-    HEADER_SIZE: HEADER_SIZE
+    HEADER_SIZE: HEADER_SIZE,
+    parsedModuleToDescribe,
 };

--- a/specs/lib/ModuleInfo.spec.js
+++ b/specs/lib/ModuleInfo.spec.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const path = require('path');
+const HalModuleParser = require('../../lib/HalModuleParser.js');
+const ModuleInfo = require('../../lib/ModuleInfo.js');
+var should = require('should');
+
+const settings = {
+	binaries: path.resolve(path.join(__dirname, '../binaries'))
+};
+
+describe('ModuleInfo', () => {
+
+	it('converts an application file to a describe module', () => {
+
+		var filename = path.join(settings.binaries, '040_user-part.bin');
+		var expectedPrefixInfo = {
+			moduleStartAddy: '80a0000',
+			moduleEndAddy: '80a128c',
+			moduleFlags: ModuleInfo.Flags.NONE,
+			moduleVersion: 2,
+			platformID: 6,
+			moduleFunction: 5,
+			moduleIndex: 1,
+			depModuleFunction: 4,
+			depModuleIndex: 2,
+			depModuleVersion: 1,
+			dep2ModuleFunction: 0,
+			dep2ModuleIndex: 0,
+			dep2ModuleVersion: 0
+		};
+
+		const expectedDescribe = {
+			n: '1',
+			f: 'u',
+			v: 2,
+			d: [
+				{ f: 's', v: 1, n: '2' }        // note that the name is a string, while version is not.
+			]
+		};
+
+		var parser = new HalModuleParser();
+		return parser.parseFile(filename)
+			.then(fileInfo => {
+				//console.log('got user info ', fileInfo.prefixInfo);
+				should(fileInfo).be.ok;
+				should(fileInfo.crc.ok).be.ok;
+				should(fileInfo.prefixInfo).eql(expectedPrefixInfo);
+
+				const describe = ModuleInfo.parsedModuleToDescribe(fileInfo);
+				should(describe).eql(expectedDescribe);
+			});
+	});
+
+});


### PR DESCRIPTION
changes required to support flashing the device-os first.  Key changes:

* convert a parsed module info to the `describe` format emitted by the device
* reject parsing small files (there are no boundary checks so parsing often fails with an exception rather than a rejection)