### PR TITLE
feature/sc-88699/add-tron-platform

### DIFF
--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+const deviceConstants = require('@particle/device-constants');
 
 const ModuleFunction = {
     NONE: 0,
@@ -67,20 +68,16 @@ const ModuleValidationFlags = {
     DEPENDENCIES_FULL: (1 << 6)
 };
 
-const ModuleInfoPlatform = {
-    CORE: 0,
-    PHOTON: 6,
-    P1: 8,
-    ELECTRON: 10,
-    ARGON: 12,
-    BORON: 13,
-    XENON: 14,
-    ASOM: 22,
-    BSOM: 23,
-    XSOM: 24,
-    B5SOM: 25,
-    ASSETTRACKER: 26
-};
+const ModuleInfoPlatform = Object.values(deviceConstants)
+    .filter(p => p.generation > 0)
+    .reduce((out, p) => {
+        out[p.name.toUpperCase()] = p.id;
+        return out;
+    }, {});
+
+
+// TODO (mirande): legacy name, remove for v2
+ModuleInfoPlatform.ASSETTRACKER = 26
 
 /**
  * The size of a module's prefix data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@particle/device-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.0.tgz",
+      "integrity": "sha512-iVmXQgcB6sIoX19DQKeAPsBaxIAhgXYpS7hQOs0LyZzrH4R9KKBfqEz/Ge6iF2iIZ6I1YU79rnGebVKZcZi22w=="
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@particle/device-constants": "^1.0.0",
     "buffer-crc32": "^0.2.5",
     "when": "^3.7.3",
     "xtend": "^4.0.2"


### PR DESCRIPTION
## Description

Adds `@particle/device-constants` dependency and the new `p2` (aka "tron") platform.


## How to Test

1. Pull down this branch (`git pull && git checkout feature/sc-88699/add-tron-platform`)
2. Reinstall dependencies (`npm ci`)
3. Run tests (`npm test`)

**Outcome**

Dependencies install successfully and tests pass 👍


## Related / Discussions

https://app.shortcut.com/particle/story/88699/update-binary-version-reader-to-support-tron-platform
https://app.shortcut.com/particle/epic/88674/tron-platform-support