### PR TITLE
feature/sc-88699/device-constants-as-peerdependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,10 @@
       }
     },
     "@particle/device-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.0.tgz",
-      "integrity": "sha512-iVmXQgcB6sIoX19DQKeAPsBaxIAhgXYpS7hQOs0LyZzrH4R9KKBfqEz/Ge6iF2iIZ6I1YU79rnGebVKZcZi22w=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.1.tgz",
+      "integrity": "sha512-2WXzDC749vosH8xWIAJ1KGt/a3WzJEq1qabHcZSIaYrEmRgYTcY2ndqD643ivX9dNT1Uqpzpm348PnBAQjJ7wQ==",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.2",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@particle/device-constants": "^1.0.0",
     "buffer-crc32": "^0.2.5",
     "when": "^3.7.3",
     "xtend": "^4.0.2"
   },
+  "peerDependencies": {
+    "@particle/device-constants": "^1.0.0"
+  },
   "devDependencies": {
+    "@particle/device-constants": "^1.0.1",
     "buffer-offset": "^0.1.2",
     "chai": "^3.5.0",
     "coveralls": "^3.0.7",


### PR DESCRIPTION
## Description

Makes `@particle/device-constants` a peer dependency so consuming apps are able to manage the dependency and updates are generally easier


## How to Test

1. Pull down this branch (`git pull && git checkout feature/sc-88699/device-constants-as-peerdependency`)
2. Reinstall dependencies (`npm i`)
3. Run tests (`npm test`)

**Outcome**

Dependencies install successfully, lockfile shows no edits, and tests pass 👍


## Related / Discussions

https://app.shortcut.com/particle/story/88699/update-binary-version-reader-to-support-tron-platform
https://app.shortcut.com/particle/epic/88674/tron-platform-support