### PR TITLE
Update device-constants to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "binary-version-reader",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer-crc32": "^0.2.5",
@@ -17,7 +17,7 @@
         "pmod": "bin/pmod.js"
       },
       "devDependencies": {
-        "@particle/device-constants": "^2.0.0",
+        "@particle/device-constants": "^3.0.1",
         "buffer-offset": "^0.1.2",
         "chai": "^3.5.0",
         "coveralls": "^3.0.7",
@@ -30,7 +30,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "2.x"
+        "@particle/device-constants": "^3.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.0.0.tgz",
-      "integrity": "sha512-GGcebFK/A7trvUnXhyq3sWq6XvX/GSO6AJsjFFiDm9Qs+UtgmlVuPdLW6xaZR7gZgMT+siBhnxvZg+iDTEfTsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
+      "integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -2462,9 +2462,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.0.0.tgz",
-      "integrity": "sha512-GGcebFK/A7trvUnXhyq3sWq6XvX/GSO6AJsjFFiDm9Qs+UtgmlVuPdLW6xaZR7gZgMT+siBhnxvZg+iDTEfTsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
+      "integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "xtend": "^4.0.2"
   },
   "peerDependencies": {
-    "@particle/device-constants": "2.x"
+    "@particle/device-constants": "^3.0.1"
   },
   "devDependencies": {
-    "@particle/device-constants": "^2.0.0",
+    "@particle/device-constants": "^3.0.1",
     "buffer-offset": "^0.1.2",
     "chai": "^3.5.0",
     "coveralls": "^3.0.7",


### PR DESCRIPTION
This PR updates the peer dependency on `@particle/device-constants` to 3.0.1 to fix warnings (or errors depending on the npm version) in projects that depend on a higher version of that package.

The breaking change introduced in `device-constants@3.0.0` only affects the billing service: https://github.com/particle-iot-inc/device-constants/commit/4d81f0874284c1620979db8c53100d69cbda5ead.