### PR TITLE
Update device-constants to 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "pmod": "bin/pmod.js"
       },
       "devDependencies": {
-        "@particle/device-constants": "^3.1.6",
+        "@particle/device-constants": "^3.1.7",
         "buffer-offset": "^0.1.2",
         "chai": "^3.5.0",
         "coveralls": "^3.0.7",
@@ -30,7 +30,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "^3.1.6"
+        "@particle/device-constants": "^3.1.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
-      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.7.tgz",
+      "integrity": "sha512-us7uxWZMQL2VSCh4J3ViyQ3wgs8Xee7ay8VX0+fxJloNoHHWuv/9/U5Y/FEBmdDUh1SSLJ6oo3FTQR4S5Cg8aw==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -2462,9 +2462,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
-      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.7.tgz",
+      "integrity": "sha512-us7uxWZMQL2VSCh4J3ViyQ3wgs8Xee7ay8VX0+fxJloNoHHWuv/9/U5Y/FEBmdDUh1SSLJ6oo3FTQR4S5Cg8aw==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "xtend": "^4.0.2"
   },
   "peerDependencies": {
-    "@particle/device-constants": "^3.1.6"
+    "@particle/device-constants": "^3.1.7"
   },
   "devDependencies": {
-    "@particle/device-constants": "^3.1.6",
+    "@particle/device-constants": "^3.1.7",
     "buffer-offset": "^0.1.2",
     "chai": "^3.5.0",
     "coveralls": "^3.0.7",


### PR DESCRIPTION
### Description 

Update device-constants to 3.1.6 to support the new Orson platform

### How to test 

Provide binaries built for the new 'muon' platform and verify that results of BVR are as expected

Additionally,
1. Pull the branch: `chore/sc-104115/update-binary-version-reader-to-node-js-v16`
2. Update your local node version to v16.x and npm to version to v8.x. Use nvm use 16 or equivalent.
3. Verify your updates: node -v && npm -v
4. Install dependencies: npm i
5. Run the tests npm run test