### PR TITLE
Update device-constants to 3.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "pmod": "bin/pmod.js"
       },
       "devDependencies": {
-        "@particle/device-constants": "^3.1.7",
+        "@particle/device-constants": "^3.1.8",
         "buffer-offset": "^0.1.2",
         "chai": "^3.5.0",
         "coveralls": "^3.0.7",
@@ -30,7 +30,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "^3.1.7"
+        "@particle/device-constants": "^3.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.7.tgz",
-      "integrity": "sha512-us7uxWZMQL2VSCh4J3ViyQ3wgs8Xee7ay8VX0+fxJloNoHHWuv/9/U5Y/FEBmdDUh1SSLJ6oo3FTQR4S5Cg8aw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.8.tgz",
+      "integrity": "sha512-LSmd16a353BxM7G1ek6Vrv6v8IIiAXUUS5zVuQTFtlKljrFDz06WFEm2UkX0bP2z//f2aROLPZ82rXBwcMOUSQ==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -2462,9 +2462,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.7.tgz",
-      "integrity": "sha512-us7uxWZMQL2VSCh4J3ViyQ3wgs8Xee7ay8VX0+fxJloNoHHWuv/9/U5Y/FEBmdDUh1SSLJ6oo3FTQR4S5Cg8aw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.8.tgz",
+      "integrity": "sha512-LSmd16a353BxM7G1ek6Vrv6v8IIiAXUUS5zVuQTFtlKljrFDz06WFEm2UkX0bP2z//f2aROLPZ82rXBwcMOUSQ==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "xtend": "^4.0.2"
   },
   "peerDependencies": {
-    "@particle/device-constants": "^3.1.7"
+    "@particle/device-constants": "^3.1.8"
   },
   "devDependencies": {
-    "@particle/device-constants": "^3.1.7",
+    "@particle/device-constants": "^3.1.8",
     "buffer-offset": "^0.1.2",
     "chai": "^3.5.0",
     "coveralls": "^3.0.7",


### PR DESCRIPTION
### Description
Update device-constants to 3.1.8 to rename moun to msom

### References
https://app.shortcut.com/particle/story/117445/change-muon-to-msom-in-cli-tools