### PR TITLE
feat: [sc-118345] Binary version reader: tweaks after testing

### DIFF
--- a/lib/firmwareTestHelper.js
+++ b/lib/firmwareTestHelper.js
@@ -1,61 +1,56 @@
 'use strict';
 
-const { FunctionType, MODULE_PREFIX_SIZE } = require('./ModuleInfo');
-const { crc32 } = require('./utilities.js');
-
-const crypto = require('crypto');
+const { randomFillSync } = require('crypto');
+const ModuleInfo = require('./ModuleInfo');
+const { updateModulePrefix, updateModuleSuffix, updateModuleSha256, updateModuleCrc32 } = require('./moduleEncoding');
 
 module.exports = {
 	// Creates a valid firmware binary for usage in tests
 	createFirmwareBinary({
-			buffer = Buffer.from('dummy'),
-			addVectorTable = false,
-			vectorTableSize = 388,
-			moduleStartAddress = 0x08000000,
 			productId,
 			productVersion,
 			platformId,
-			moduleFunction = FunctionType.USER_PART,
+			moduleFunction = ModuleInfo.FunctionType.USER_PART,
 			moduleIndex = 1,
-			depModuleFunction = FunctionType.SYSTEM_PART,
-			depModuleIndex = 1,
-			depModuleVersion = 1000	} = {}) {
-		const suffixLength = 40;
-		if (typeof productId === 'undefined') {
-			productId = 0xFFFF;
-		}
-		if (typeof productVersion === 'undefined') {
-			productVersion = 0xFFFF;
-		}
-		if (buffer.length < 512) {
-			// HalModuleParser fails if the module is too small
-			buffer = Buffer.concat([buffer, Buffer.alloc(512 - buffer.length, 0)]);
-		}
-		const vectorTable = Buffer.alloc(addVectorTable ? vectorTableSize : 0, 0);
+			moduleVersion = 1,
+			deps = [],
+			addVectorTable = false,
+			vectorTableSize = 388,
+			moduleStartAddress = 0x08000000,
+			dataSize = 1024
+		} = {}) {
 
-		// Offsets correspond to HalModuleParser.js#L299
-		const prefix = Buffer.alloc(MODULE_PREFIX_SIZE, 0);
-		prefix.writeUInt32LE(moduleStartAddress, 0);
-		prefix.writeUInt32LE(moduleStartAddress + vectorTable.length + prefix.length + buffer.length + suffixLength, 4);
-		prefix.writeUInt16LE(platformId, 12);
-		prefix.writeUInt8(moduleFunction, 14);
-		prefix.writeUInt8(moduleIndex, 15);
-		prefix.writeUInt8(depModuleFunction, 16);
-		prefix.writeUInt8(depModuleIndex, 17);
-		prefix.writeUInt16LE(depModuleVersion, 18);
-		const fwBuffer = Buffer.concat([vectorTable, prefix, buffer, Buffer.alloc(suffixLength, 0)]);
-		fwBuffer.writeUInt16LE(productId, fwBuffer.length - suffixLength);
-		fwBuffer.writeUInt16LE(productVersion, fwBuffer.length - suffixLength + 2);
-		fwBuffer.writeUInt16LE(0, fwBuffer.length - suffixLength + 4);
-		fwBuffer.writeUInt16LE(suffixLength, fwBuffer.length - 2);
+		const prefixOffset = addVectorTable ? vectorTableSize : 0;
+		const binary = Buffer.alloc(ModuleInfo.MODULE_PREFIX_SIZE + prefixOffset + dataSize + ModuleInfo.MIN_MODULE_SUFFIX_SIZE + 2 /* Product ID */ +
+			2 /* Product version */ + 4 /* CRC-32 */, 0xff);
+		// Part of the module data is filled with 0xff so that the module is compressible
+		randomFillSync(binary, ModuleInfo.MODULE_PREFIX_SIZE + prefixOffset, Math.floor(dataSize / 2));
 
-		const hashOffset = fwBuffer.length - 2 /* Suffix size */ - 32 /* SHA-256 */;
-		let hash = crypto.createHash('sha256');
-		hash.update(fwBuffer.slice(0, hashOffset));
-		hash = hash.digest();
-		hash.copy(fwBuffer, hashOffset);
-
-		const crc = crc32(fwBuffer);
-		return Buffer.concat([fwBuffer, crc]);
+		updateModulePrefix(binary, {
+			prefixOffset,
+			moduleStartAddy: moduleStartAddress,
+			moduleEndAddy: moduleStartAddress + binary.length - 4 /* CRC-32 */,
+			reserved: 0,
+			moduleFlags: 0,
+			moduleVersion,
+			platformID: platformId,
+			moduleFunction,
+			moduleIndex,
+			depModuleFunction: (deps.length >= 1) ? deps[0].func : ModuleInfo.FunctionType.NONE,
+			depModuleIndex: (deps.length >= 1) ? deps[0].index : 0,
+			depModuleVersion: (deps.length >= 1) ? deps[0].version : 0,
+			dep2ModuleFunction: (deps.length >= 2) ? deps[1].func : ModuleInfo.FunctionType.NONE,
+			dep2ModuleIndex: (deps.length >= 2) ? deps[1].index : 0,
+			dep2ModuleVersion: (deps.length >= 2) ? deps[1].version : 0
+		});
+		updateModuleSuffix(binary, {
+			suffixSize: ModuleInfo.MIN_MODULE_SUFFIX_SIZE + 2 /* Product ID */ + 2 /* Product version */,
+			productId,
+			productVersion,
+			reserved: 0
+		});
+		updateModuleSha256(binary);
+		updateModuleCrc32(binary);
+		return binary;
 	}
 };

--- a/lib/moduleEncoding.js
+++ b/lib/moduleEncoding.js
@@ -1229,6 +1229,23 @@ async function splitCombinedModules(data, options) {
 	return mods;
 }
 
+/**
+ * Check if the hash of the provided asset binary matches the asset info stored in the application binary
+ * @param {Buffer} asset - the bytes of the asset
+ * @param {object} assetInfo - the asset info block from the assets array returned by parseBuffer
+ * @returns {boolean} true if the asset matches the asset info, false otherwise. Throws if the asset
+ */
+function isAssetValid(asset, assetInfo) {
+	if (assetInfo.hashType !== ModuleInfo.ModuleInfoHashExtensionType.SHA256) {
+		throw new Error('Invalid asset hash type');
+	}
+	const assetHash = crypto.createHash('sha256');
+	assetHash.update(asset);
+	const assetHashHex = assetHash.digest('hex');
+
+	return assetHashHex === assetInfo.hash;
+};
+
 module.exports = {
 	updateModuleSha256,
 	updateModuleCrc32,
@@ -1243,5 +1260,6 @@ module.exports = {
 	unwrapAssetModule,
 	createApplicationAndAssetBundle,
 	unpackApplicationAndAssetBundle,
-	sanitizeAddress
+	sanitizeAddress,
+	isAssetValid
 };

--- a/lib/moduleEncoding.js
+++ b/lib/moduleEncoding.js
@@ -610,11 +610,11 @@ async function compressModule(data, options) {
  * Update module info to include a set of asset dependencies
  *
  * @param {Buffer} data Module to update
- * @param {Array} [assets] List of assets to add as dependencies
+ * @param {Array} assets List of assets to add as dependencies
  * @returns {Promise<Buffer>}
  */
 async function updateModuleAssetDependencies(data, assets) {
-	if (!assets || assets.length === 0) {
+	if (assets.length === 0) {
 		throw new RangeError('Empty asset dependency list');
 	}
 	const parser = new HalModuleParser();
@@ -918,7 +918,13 @@ async function createApplicationAndAssetBundle(application, assets) {
 			processedAssets.push(asset);
 		}
 	}
-	const updated = await updateModuleAssetDependencies(app.data, processedAssets);
+
+	let updated;
+	if (processedAssets.length > 0) {
+		updated = await updateModuleAssetDependencies(app.data, processedAssets);
+	} else {
+		updated = app.data;
+	}
 
 	return await tmp.withFile(async ({path, fd}) => {
 		await new Promise((resolve, reject) => {

--- a/specs/lib/firmwareTestHelper.js
+++ b/specs/lib/firmwareTestHelper.js
@@ -2,6 +2,7 @@
 const expect = require('chai').expect;
 const firmwareTestHelper = require('../../lib/firmwareTestHelper');
 const HalModuleParser = require('../../lib/HalModuleParser');
+const ModuleInfo = require('../../lib/ModuleInfo');
 
 describe('firmwareTestHelper', function() {
 	describe('createFirmwareBinary', function() {
@@ -10,8 +11,15 @@ describe('firmwareTestHelper', function() {
 			const productVersion = 3;
 			const platformId = 6;
 			const depModuleVersion = 1234;
+			const deps = [
+				{
+					func: ModuleInfo.FunctionType.SYSTEM_PART,
+					index: 1,
+					version: depModuleVersion
+				}
+			];
 
-			const binary = firmwareTestHelper.createFirmwareBinary({ productId, productVersion, platformId, depModuleVersion });
+			const binary = firmwareTestHelper.createFirmwareBinary({ productId, productVersion, platformId, deps });
 
 			const parser = new HalModuleParser();
 			return parser.parseBuffer({ fileBuffer: binary }).then((fileInfo) => {
@@ -29,8 +37,15 @@ describe('firmwareTestHelper', function() {
 			const productVersion = 3;
 			const platformId = 6;
 			const depModuleVersion = 1234;
+			const deps = [
+				{
+					func: ModuleInfo.FunctionType.SYSTEM_PART,
+					index: 1,
+					version: depModuleVersion
+				}
+			];
 
-			const binary = firmwareTestHelper.createFirmwareBinary({ productId, productVersion, platformId, depModuleVersion,
+			const binary = firmwareTestHelper.createFirmwareBinary({ productId, productVersion, platformId, deps,
 					addVectorTable: true });
 
 			const parser = new HalModuleParser();

--- a/specs/lib/moduleEncoding.spec.js
+++ b/specs/lib/moduleEncoding.spec.js
@@ -12,7 +12,8 @@ const {
 	createApplicationAndAssetBundle,
 	unpackApplicationAndAssetBundle,
 	updateModuleAssetDependencies,
-	sanitizeAddress
+	sanitizeAddress,
+	isAssetValid
 } = require('../../lib/moduleEncoding');
 
 const HalModuleParser = require('../../lib/HalModuleParser');
@@ -29,6 +30,7 @@ chai.use(chaiExclude);
 const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
+const ModuleInfo = require('../../lib/ModuleInfo');
 
 const TEST_BINARIES_PATH = path.resolve(path.join(__dirname, '../binaries'));
 
@@ -695,6 +697,50 @@ describe('moduleEncoding', () => {
 			expect(unpacked.application.data.equals(application)).to.be.true;
 			expect(unpacked.application.name).to.equal(path.basename(app));
 			expect(unpacked.assets).be.eql([]);
+		});
+	});
+
+	describe('isAssetValid', () => {
+		it('returns true if the asset binary matches the hash', async () => {
+			const asset = await fs.promises.readFile(TEST_ASSETS[0]);
+			const assetInfo = {
+				type: ModuleInfo.ModuleInfoExtension.ASSET_DEPENDENCY,
+				hashType: ModuleInfo.ModuleInfoHashExtensionType.SHA256,
+				hash: crypto.createHash('sha256').update(asset).digest('hex'),
+				name: path.basename(TEST_ASSETS[0])
+			};
+
+			expect(isAssetValid(asset, assetInfo)).to.be.true;
+		});
+
+		it('returns false if the asset binary does not match the hash', async () => {
+			const asset = await fs.promises.readFile(TEST_ASSETS[0]);
+			const assetInfo = {
+				type: ModuleInfo.ModuleInfoExtension.ASSET_DEPENDENCY,
+				hashType: ModuleInfo.ModuleInfoHashExtensionType.SHA256,
+				hash: 'eac63541cfbeba37b8ec819b73c16b7f193c6cacbb810cdba1b3a49809dff5d0',
+				name: path.basename(TEST_ASSETS[0])
+			};
+
+			expect(isAssetValid(asset, assetInfo)).to.be.false
+		});
+
+		it('throws if the hash type is unknown', async () => {
+			const asset = await fs.promises.readFile(TEST_ASSETS[0]);
+			const assetInfo = {
+				type: ModuleInfo.ModuleInfoExtension.ASSET_DEPENDENCY,
+				hashType: ModuleInfo.ModuleInfoHashExtensionType.SHA256 + 1,
+				hash: 'eac63541cfbeba37b8ec819b73c16b7f193c6cacbb810cdba1b3a49809dff5d0',
+				name: path.basename(TEST_ASSETS[0])
+			};
+
+			let error;
+			try {
+				isAssetValid(asset, assetInfo);
+			} catch (e) {
+				error = e;
+			}
+			expect(error).to.be.instanceOf(Error).with.property('message', 'Invalid asset hash type');
 		});
 	});
 });

--- a/specs/lib/moduleEncoding.spec.js
+++ b/specs/lib/moduleEncoding.spec.js
@@ -643,7 +643,6 @@ describe('moduleEncoding', () => {
 			}
 		});
 
-
 		it('creates application and assets bundle for P2 user application from Buffers', async () => {
 			const assets = TEST_ASSETS.map(f => { return { data: fs.readFileSync(f), name: path.basename(f) }});
 			const application = fs.readFileSync(path.join(TEST_BINARIES_PATH, 'p2-tinker@5.3.1.bin'));
@@ -686,6 +685,16 @@ describe('moduleEncoding', () => {
 			expect(unpacked.application.data.equals(application)).to.be.false;
 			expect(unpacked.application.name).to.equal(path.basename(app));
 			expect(unpacked.assets).eql(assets);
+		});
+
+		it('creates application bundle when there are no assets', async () => {
+			const application = fs.readFileSync(path.join(TEST_BINARIES_PATH, 'tracker-tinker@5.3.1.bin'));
+			const app = path.join(TEST_BINARIES_PATH, 'tracker-tinker@5.3.1.bin');
+			const bundle = await createApplicationAndAssetBundle(app, []);
+			const unpacked = await unpackApplicationAndAssetBundle(bundle);
+			expect(unpacked.application.data.equals(application)).to.be.true;
+			expect(unpacked.application.name).to.equal(path.basename(app));
+			expect(unpacked.assets).be.eql([]);
 		});
 	});
 });


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/118345

- Allow creating a zipped bundle with 0 assets
- Rework `createFirmwareBinary` to use the methods from moduleEncoding

The change to `createFirmwareBinary` would deserve a major version bump, but since the only user are tests by internal services, I'd prefer to release a minor bump and I will ensure that all internal services are updated to use the new syntax: `deps` array and `dataSize`.