### PR TITLE
missing throw error after 'when' migration

### DIFF
--- a/lib/HalModuleParser.js
+++ b/lib/HalModuleParser.js
@@ -109,6 +109,7 @@ HalModuleParser.prototype = {
 			if (callback) {
 				callback(null, error);
 			}
+			throw error;
 		}
 	},
 

--- a/lib/HalModuleParser.js
+++ b/lib/HalModuleParser.js
@@ -50,26 +50,26 @@ HalModuleParser.prototype = {
 	 * @returns {*}
 	 */
 	parseFile: async function(filename, callback) {
-		var fileInfo = {
+		const fileInfo = {
 			filename: filename
 		};
 
 		let fileBuffer = await this._loadFile(filename);
 		fileInfo.fileBuffer = fileBuffer;
 
-		let allDone = this.parseBuffer(fileInfo);
+		try {
+			const allDone = await this.parseBuffer(fileInfo);
+			if (callback) {
+				callback(allDone, null);
+			}
+			return allDone;
 
-		if (callback) {
-			allDone.then(
-				function(info) {
-					callback(info, null);
-				},
-				function(err) {
-					callback(null, err);
-				});
+		} catch (error) {
+			if (callback) {
+				callback(null, error);
+			}
+			throw error;
 		}
-
-		return allDone;
 	},
 
 


### PR DESCRIPTION
After the "when" removal, every time the `parseBuffer` failed the error were "ignored" and just return `undefined`