### PR TITLE
update device-constants to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "pmod": "bin/pmod.js"
       },
       "devDependencies": {
-        "@particle/device-constants": "^3.5.0",
+        "@particle/device-constants": "^3.6.0",
         "buffer-offset": "^0.1.2",
         "chai": "^4.0.0",
         "chai-as-promised": "^7.1.1",
@@ -34,7 +34,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "^3.5.0"
+        "@particle/device-constants": "^3.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -281,9 +281,9 @@
       "dev": true
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.5.0.tgz",
-      "integrity": "sha512-dJ85XvE+TrWHCkFP3pOkHloWuSdMSnCMzPdNrdEfXqs/ejwGUEi6G3w5DE0p4saT1KDD7VtRMpn1FHzFW4K5vA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.6.0.tgz",
+      "integrity": "sha512-aYHJKqIUZnKE2j21bqMhZRFpaMuSedr/ttxWaicEaMaTMY5vt6IMHpX6LJO9VWT/5RJCTLzbyzf3MZKHgga22A==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -3151,9 +3151,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.5.0.tgz",
-      "integrity": "sha512-dJ85XvE+TrWHCkFP3pOkHloWuSdMSnCMzPdNrdEfXqs/ejwGUEi6G3w5DE0p4saT1KDD7VtRMpn1FHzFW4K5vA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.6.0.tgz",
+      "integrity": "sha512-aYHJKqIUZnKE2j21bqMhZRFpaMuSedr/ttxWaicEaMaTMY5vt6IMHpX6LJO9VWT/5RJCTLzbyzf3MZKHgga22A==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "xtend": "^4.0.2"
   },
   "peerDependencies": {
-    "@particle/device-constants": "^3.5.0"
+    "@particle/device-constants": "^3.6.0"
   },
   "devDependencies": {
-    "@particle/device-constants": "^3.5.0",
+    "@particle/device-constants": "^3.6.0",
     "buffer-offset": "^0.1.2",
     "chai": "^4.0.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
### Description 

Update device-constants to 3.6.0 to support the new Electron 2 platform

### How to test 

Provide binaries built for the new 'muon' platform and verify that results of BVR are as expected