### PR TITLE
Update publish CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,21 +52,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          registry-url: 'https://registry.npmjs.org'
           node-version: '16'
           cache: 'npm'
       - name: Install Dependencies
         run: |
           npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+          npm whoami
           npm ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build & Publish Packages
         run: |
-          npm publish
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+          npm whoami
+          # Publish as beta for pre-release tags like v1.2.3-rc.0 or v1.2.3-pre.1
+          [[ $GITHUB_REF_NAME =~ ^v.*- ]] && NPM_TAG=--tag=beta
+          npm publish $NPM_TAG
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
-
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Copy device-constants publish step into binary-version-reader since the npm cache seems to be failing with setup-node v2