### PR TITLE
export HalModuleParser to use it directly

### DIFF
--- a/limited.js
+++ b/limited.js
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2015 Particle ( https://particle.io )
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Browser-safe entry point.
+ *
+ * Exports only modules that work in the browser (no fs, crypto, zlib, etc.).
+ * Requires stubbing `fs` in the bundler (e.g. webpack resolve.fallback: { fs: false }).
+ */
+
+module.exports = {
+	HalModuleParser: require('./lib/HalModuleParser.js'),
+	ModuleInfo: require('./lib/ModuleInfo.js'),
+};

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "main": "main.js",
   "exports": {
     ".": "./main.js",
-    "./HalModuleParser": "./lib/HalModuleParser.js",
-    "./ModuleInfo": "./lib/ModuleInfo.js",
-    "./lib/*": "./lib/*"
+    "./limited": "./limited.js"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "binary-version-reader",
   "version": "4.0.2",
   "main": "main.js",
+  "exports": {
+    ".": "./main.js",
+    "./HalModuleParser": "./lib/HalModuleParser.js",
+    "./ModuleInfo": "./lib/ModuleInfo.js",
+    "./lib/*": "./lib/*"
+  },
   "license": "Apache-2.0",
   "engines": {
     "node": ">=12",


### PR DESCRIPTION
Export HalModuleParser to easily import it in projects.