### PR TITLE
fix: [sc-139428] binary-version-reader` CLI output is not valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,42 +16,54 @@ If you're building firmware on the Particle Platform, you might be curious to se
     });
 ```
 
-You can also get the raw output of binary-version-reader by using it as a command line tool without installing it.
+You can also inspect a firmware binary from the command line without installing the package:
 
 ```
 npx binary-version-reader your_binary.bin
+```
+
+The output is valid JSON, suitable for piping into other tools:
+
+```
+npx binary-version-reader your_binary.bin | jq '.prefixInfo.moduleVersion'
 ```
 
 ## Example output
 
 ```json
 {
-	"filename": "/.../040_user-part.bin",
-	"fileBuffer": "<Buffer ...>",
-	"crc": {
-		"ok": 1,
-		"storedCrc": "b138f375",
-		"actualCrc": "b138f375"
-	},
-	"prefixInfo": {
-		"moduleStartAddy": "80a0000",
-		"moduleEndAddy": "80a128c",
-		"moduleVersion": 2,
-		"platformID": 6,
-		"moduleFunction": 5,
-		"moduleIndex": 1,
-		"depModuleFunction": 4,
-		"depModuleIndex": 2,
-		"depModuleVersion": 1
-	},
-	"suffixInfo": {
-		"productId": -1,
-		"productVersion": -1,
-		"fwUniqueId": "f9f552aa98d7e3eab750862a01743024a4d05514021598a4341b3d83b37eda36",
-		"reserved": 0,
-		"suffixSize": 36,
-		"crcBlock": "b138f375"
-	}
+  "filename": "your_binary.bin",
+  "crc": {
+    "ok": true,
+    "storedCrc": "b138f375",
+    "actualCrc": "b138f375"
+  },
+  "prefixInfo": {
+    "moduleStartAddy": "80a0000",
+    "moduleEndAddy": "80a128c",
+    "reserved": 0,
+    "moduleFlags": 0,
+    "moduleVersion": 2,
+    "platformID": 6,
+    "moduleFunction": 5,
+    "moduleIndex": 1,
+    "depModuleFunction": 4,
+    "depModuleIndex": 2,
+    "depModuleVersion": 1,
+    "dep2ModuleFunction": 0,
+    "dep2ModuleIndex": 0,
+    "dep2ModuleVersion": 0,
+    "prefixSize": 24,
+    "prefixOffset": 0
+  },
+  "suffixInfo": {
+    "productId": -1,
+    "productVersion": -1,
+    "fwUniqueId": "f9f552aa98d7e3eab750862a01743024a4d05514021598a4341b3d83b37eda36",
+    "reserved": 0,
+    "suffixSize": 36,
+    "crcBlock": "b138f375"
+  }
 }
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,20 @@ if (args.length <= 2) {
 var filename = process.argv[2];
 
 
-p.parseFile(filename, function() {
-	console.dir(arguments, { depth: null });
+p.parseFile(filename, function(result, error) {
+	if (error) {
+		console.error(error.message || error);
+		process.exit(1);
+	}
+	delete result.fileBuffer;
+	const replacer = (key, value) => {
+		if (value && value.type === 'Buffer' && Array.isArray(value.data)) {
+			return Buffer.from(value.data).toString('hex');
+		}
+		return value;
+	};
+	console.log(JSON.stringify(result, replacer, 2));
+}).catch(function(err) {
+	console.error(err.message || err);
+	process.exit(1);
 });

--- a/specs/lib/cli.spec.js
+++ b/specs/lib/cli.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+var { spawnSync } = require('child_process');
+
+var CLI = path.resolve(__dirname, '../../cli.js');
+var BINARIES = path.resolve(__dirname, '../binaries');
+
+describe('CLI', function () {
+	it('outputs valid JSON for a valid binary', function () {
+		var result = spawnSync(process.execPath, [CLI, path.join(BINARIES, 'p2-tinker@5.3.1.bin')]);
+		var stdout = result.stdout.toString();
+		var parsed = JSON.parse(stdout);
+		parsed.should.have.property('prefixInfo');
+		parsed.should.have.property('suffixInfo');
+		parsed.should.have.property('crc');
+		parsed.should.not.have.property('fileBuffer');
+	});
+
+	it('exits with code 1 and prints to stderr when file does not exist', function () {
+		var result = spawnSync(process.execPath, [CLI, 'nonexistent.bin']);
+		result.status.should.equal(1);
+		result.stderr.toString().should.match(/doesn't exist/);
+	});
+});


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/139428

Make the output of `npx binary-version-reader` usable as JSON.